### PR TITLE
i18n version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,14 @@ PATH
   specs:
     cache-flow (0.0.6)
       activesupport (>= 3.1.0)
-      i18n (= 0.7.0)
+      i18n (>= 0.6.9)
       tzinfo (= 0.3.38)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
+    activesupport (4.0.3)
+      i18n (~> 0.6, >= 0.6.4)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)

--- a/cache-flow.gemspec
+++ b/cache-flow.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/dandemeyere/cache-flow'
   s.license     = 'MIT'
   s.add_dependency('activesupport','>= 3.1.0')
-  s.add_dependency('i18n','0.7.0')
+  s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('tzinfo', '0.3.38')
   s.add_development_dependency('rspec', '3.2.0')
 end


### PR DESCRIPTION
@dandemeyere can you :ship: and publish please?
## Why again?

Because I messed up. Originally wanted to use i18n 0.7.0 in responsys-api but because not all Rails apps are using the v4 (i18n v0.7.0) this is not making the GEM compatible with Rails v3 (i18n v0.6.9).

So going back to that line and making it at least 0.6.9 for Rails 3 apps (yes ours). I'm also changing the version in the Responsys GEM to do the same.

Thanks
